### PR TITLE
Enable stateful set to start in an istio cluster

### DIFF
--- a/mysqloperator/controller/innodbcluster/cluster_objects.py
+++ b/mysqloperator/controller/innodbcluster/cluster_objects.py
@@ -136,6 +136,7 @@ spec:
         component: mysqld
         tier: mysql
         mysql.oracle.com/cluster: {spec.name}
+        sidecar.istio.io/inject: "false"
     spec:
       subdomain: {spec.name}
 {utils.indent(spec.image_pull_secrets, 6)}


### PR DESCRIPTION
by making this change i was able to get the cluster to startup within an istio cluster. This isn't the ideal solution as having an Istio virtual service routing to it would be more preferred but this change will at least allow This operator to be used out of the box within an Istio cluster.