### PR TITLE
Added missing imports in kutil.py

### DIFF
--- a/tests/utils/kutil.py
+++ b/tests/utils/kutil.py
@@ -14,6 +14,8 @@ import time
 import re
 import yaml
 import base64
+import pathlib
+import os
 
 logger = logging.getLogger("kutil")
 


### PR DESCRIPTION
Hello i've fixed following small issues:
```
https://github.com/mysql/mysql-operator/tree/master/tests/utils/kutil.py#L678 F821 undefined name 'pathlib' 

https://github.com/mysql/mysql-operator/tree/master/tests/utils/kutil.py#L680 F821 undefined name 'os'
```


