### PR TITLE
StorageClass usage example in InnoDBCluster example

### DIFF
--- a/samples/sample-cluster.yaml
+++ b/samples/sample-cluster.yaml
@@ -7,3 +7,9 @@ spec:
   instances: 3
   router:
     instances: 1
+# An example how to use storage class with InnoDBCluster
+  datadirVolumeClaimTemplate:
+    resources:
+      requests:
+        storage: 10Gi
+    storageClassName: local


### PR DESCRIPTION
I haven't find an example how to use the InnoDBCluster with custom storageClass. I found out how to use it based on the CRD.