### PR TITLE
Add support for mycnf in mysql-innodbcluster helm chart

### DIFF
--- a/helm/mysql-innodbcluster/Chart.yaml
+++ b/helm/mysql-innodbcluster/Chart.yaml
@@ -3,5 +3,5 @@ appVersion: "8.0.28"
 name: mysql-innodbcluster
 description: MySQL InnoDB Cluster Helm Chart for deploying MySQL InnoDB Cluster in Kubernetes
 type: application
-version: "8.0.28-2.0.3"
+version: "8.0.28-2.0.4"
 icon: https://labs.mysql.com/common/themes/sakila/favicon.ico

--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -27,6 +27,11 @@ spec:
   {{- end }}
 {{- end }}
 
+{{- if .Values.mycnf }}
+  mycnf: |
+{{ .Values.mycnf | indent 4}}
+{{- end }}
+
 {{- if .Values.initDB}}
   {{- if and (and .Values.initDB.dump .Values.initDB.dump.name) (and .Values.initDB.clone .Values.initDB.donorUrl) }}
     {{- fail "Dump and Clone are mutually exclusive" }}

--- a/helm/mysql-innodbcluster/values.yaml
+++ b/helm/mysql-innodbcluster/values.yaml
@@ -30,6 +30,12 @@ baseServerId: 1000
 #    requests:
 #      storage:
 
+# mycnf: |
+#   [mysqld]
+#   max_allowed_packet=16M
+#   character-set-server=utf8mb4
+#   collation-server=utf8mb4_general_ci
+
 #initDB:
 #  dump:
 #    name:
@@ -40,7 +46,7 @@ baseServerId: 1000
 #      prefix:
 #      bucketName:
 #      credentials:
-#    persistentVolumeClaim:     
+#    persistentVolumeClaim:
 #  clone:
 #    donorUrl:
 #    rootUser:


### PR DESCRIPTION
Tested with `helm template`

```
# Source: mysql-innodbcluster/templates/deployment_cluster.yaml
apiVersion: mysql.oracle.com/v2alpha1
kind: InnoDBCluster
metadata:
  name: RELEASE-NAME
  namespace: mysql-cluster
spec:
  instances: 3
  router:
    instances: 1
  secretName: RELEASE-NAME-cluster-secret
  imagePullPolicy : IfNotPresent
  baseServerId: 1000
  version: 8.0.28
  serviceAccountName: RELEASE-NAME-sa
  datadirVolumeClaimTemplate:
    resources:
      requests:
        storage: "1Gi"
  mycnf: |
    [mysqld]
    max_allowed_packet=16M
    character-set-server=UTF8
    collation-server=utf8_general_ci
```

From mysql container
```
bash-4.4# cat /etc/my.cnf.d/99-extra.cnf
# Additional user configurations taken from spec.mycnf in InnoDBCluster.
# Do not edit directly.
[mysqld]
max_allowed_packet=16M
character-set-server=utf8mb4
collation-server=utf8mb4_general_ci
```