### PR TITLE
Optimize on_secret_create & on_innodbcluster_field_backup_schedules handlers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
 # Copyright (c) 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 #
 
-#!/bin/bash
 
 docker build --build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy} --build-arg no_proxy=${no_proxy} -t mysql/mysql-operator:8.0 .

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -5,12 +5,11 @@
 
 FROM %%MYSQL_OPERATOR_PYTHON_DEPS%%
 
-
-RUN rpm -U %%MYSQL_REPO_URL%%/mysql80-community-release-el8.rpm \
-  && microdnf update && echo "[main]" > /etc/dnf/dnf.conf \
-  && microdnf install -y mysql-shell-%%MYSQL_SHELL_VERSION%% \
-  && microdnf remove mysql80-community-release \
-  && microdnf clean all
+RUN rpm -U %%MYSQL_REPO_URL%%/mysql80-community-release-el8.rpm && \
+    microdnf update && echo "[main]" > /etc/dnf/dnf.conf && \
+    microdnf install -y mysql-shell-%%MYSQL_SHELL_VERSION%% && \
+    microdnf remove mysql80-community-release && \
+    microdnf clean all
 
 RUN groupadd -g27 mysql && useradd -u27 -g27 mysql
 

--- a/docker-deps/Dockerfile
+++ b/docker-deps/Dockerfile
@@ -11,7 +11,7 @@ ARG PYTHON_BASE_DIR
 
 RUN dnf install -y gcc git tar
 COPY ${PYTHON_TARBALL} .
-RUN mkdir -p  ${PYTHON_BASE_DIR} && cd  ${PYTHON_BASE_DIR} && tar xzf /${PYTHON_TARBALL}
+RUN mkdir -p ${PYTHON_BASE_DIR} && cd ${PYTHON_BASE_DIR} && tar -xzf /${PYTHON_TARBALL}
 ENV PATH=${PYTHON_BASE_DIR}/${PYTHON_ROOT}/bin:$PATH
 ENV LD_LIBRARY_PATH=${PYTHON_BASE_DIR}/${PYTHON_ROOT}/lib
 
@@ -22,5 +22,3 @@ RUN pip3 install --target=/tmp/site-packages -r requirements.txt
 FROM oraclelinux:8-slim
 
 COPY --from=pip-stage /tmp/site-packages /usr/lib/mysqlsh/python-packages
-
-

--- a/mysqloperator/controller/innodbcluster/operator_cluster.py
+++ b/mysqloperator/controller/innodbcluster/operator_cluster.py
@@ -605,8 +605,10 @@ def on_pod_delete(body: Body, logger: Logger, **kwargs):
         logger.error(f"Owner cluster for {pod.name} does not exist anymore")
 
 
-@kopf.on.create("", "v1", "secrets") # type: ignore
-@kopf.on.update("", "v1", "secrets") # type: ignore
+@kopf.on.create("", "v1", "secrets",
+                field="type", value="kubernetes.io/tls")  # type: ignore
+@kopf.on.update("", "v1", "secrets",
+                field="type", value="kubernetes.io/tls")  # type: ignore
 def on_secret_create(name: str, namespace: str, logger: Logger, **kwargs):
     """
     Wait for Secret objects used by clusters for TLS CA and certificate.

--- a/mysqloperator/controller/innodbcluster/operator_cluster.py
+++ b/mysqloperator/controller/innodbcluster/operator_cluster.py
@@ -408,7 +408,7 @@ def on_innodbcluster_field_backup_schedules(old: str, new: str, body: Body,
     # don't need to take actions in post_create_actions() in the cluster controller
     # but async await for Kopf to call again this handler.
     if not cluster.get_create_time():
-        raise kopf.TemporaryError("Cluster is not created or not ready."
+        raise kopf.TemporaryError("Cluster is not created or not ready. "
                                   "Will create the schedules once the first instance is up and running", delay=30)
 
     logger.info("on_innodbcluster_field_backup_schedules")

--- a/mysqloperator/sidecar_main.py
+++ b/mysqloperator/sidecar_main.py
@@ -545,8 +545,10 @@ def on_tls_secret_create_or_change(value: dict, useSelfSigned: bool, router_depl
         raise kopf.PermanentError("Timeout waiting for TLS files to get refreshed")
 
 
-@kopf.on.create("", "v1", "secrets") # type: ignore
-@kopf.on.update("", "v1", "secrets") # type: ignore
+@kopf.on.create("", "v1", "secrets",
+                field="type", value="kubernetes.io/tls")  # type: ignore
+@kopf.on.update("", "v1", "secrets",
+                field="type", value="kubernetes.io/tls")  # type: ignore
 def on_secret_create_or_update(name: str, namespace: str, spec, new, logger: Logger, **kwargs):
     global g_cluster_name
 


### PR DESCRIPTION
Optimize on_secret_create handler:
  the original register handlers all secrets' creation or updating events, then kopf framework transfer every log to k8s event, which overdriving the etcd, in some case this would even trigger OOM on etcd server which cause the k8s master break down.

Optimize on_innodbcluster_field_backup_schedules handler:
  when the InnoDBCluster is not created this handler also generates lots of events, I think we should involve a handler dynamically.
when the first InnoDBCluster created, then the handler registers.