### PR TITLE
Add option to disable lookups for mysql-operator

### DIFF
--- a/helm/mysql-operator/templates/service_account_operator.yaml
+++ b/helm/mysql-operator/templates/service_account_operator.yaml
@@ -1,3 +1,4 @@
+{{- $disable_lookups:= .Values.disableLookups }}
 {{- $install_namespace := .Release.Namespace }}
 {{- if and (.Release.IsInstall) (eq $install_namespace "default") }}
   {{ fail "Please provide a namespace with -n/--namespace . The operator cannot be installed in the 'default' namespace" }}
@@ -13,7 +14,7 @@ imagePullSecrets:
   {{- if not $secret_name }}
     {{- fail "image.pullSecrets.secretName is required when pull secrets are enabled" }}
   {{- end }}
-  {{- if not (lookup "v1" "Secret" $install_namespace $secret_name) }}
+  {{- if and (not $disable_lookups) (lookup "v1" "Secret" $install_namespace $secret_name) }}
     {{- $err := printf "image.pullSecrets.secretName: secret '%s' not found in namespace '%s'" $secret_name $install_namespace }}
     {{- fail $err }}
   {{- end }}

--- a/helm/mysql-operator/templates/service_account_operator.yaml
+++ b/helm/mysql-operator/templates/service_account_operator.yaml
@@ -14,7 +14,7 @@ imagePullSecrets:
   {{- if not $secret_name }}
     {{- fail "image.pullSecrets.secretName is required when pull secrets are enabled" }}
   {{- end }}
-  {{- if and (not $disable_lookups) (lookup "v1" "Secret" $install_namespace $secret_name) }}
+  {{- if and (not $disable_lookups) (not (lookup "v1" "Secret" $install_namespace $secret_name)) }}
     {{- $err := printf "image.pullSecrets.secretName: secret '%s' not found in namespace '%s'" $secret_name $install_namespace }}
     {{- fail $err }}
   {{- end }}

--- a/helm/mysql-operator/values.yaml
+++ b/helm/mysql-operator/values.yaml
@@ -9,8 +9,6 @@ image:
     enabled: false
     secretName:
 
-# 'lookup' functions need to be disabled while using 
-# `kubernetes kustomize` or `helm template`.
 disableLookups: false
 
 envs:

--- a/helm/mysql-operator/values.yaml
+++ b/helm/mysql-operator/values.yaml
@@ -9,6 +9,10 @@ image:
     enabled: false
     secretName:
 
+# 'lookup' functions need to be disabled while using 
+# `kubernetes kustomize` or `helm template`.
+disableLookups: false
+
 envs:
     imagesPullPolicy: IfNotPresent
     imagesDefaultRegistry: 


### PR DESCRIPTION
Debugging with helm template results in errors since 'lookup' functions return an empty interface.
Commands that fail because of this

```bash
helm install --dry-run mysql-operator
helm template mysql-operator
kubectl kustomize --enable-helm # while using charts with k8s kustomization
```

Refer issue [https://github.com/helm/helm/issues/8137](https://github.com/helm/helm/issues/8137)

Workaround is similar to `mysql-innodbcluster` implementation for [disableLookups](https://github.com/mysql/mysql-operator/blob/06b963e5b7403f7c217a1a4a4e83d9f4483c892a/helm/mysql-innodbcluster/templates/service_account_cluster.yaml#L1)