### PR TITLE
remove k8s cluster domain suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Please provide the password for 'root@mycluster': ******
 MySQL mycluster JS>
 ```
 
-Using `root@mycluster` connection assumes the default namespace is used; the long form is `{innodbclustername}.{namespace}.svc.cluster.local`. 
+Using `root@mycluster` connection assumes the default namespace is used; the long form is `{innodbclustername}.{namespace}.svc`. 
 Each MySQL instance has MySQL Shell installed that can be used when troubleshooting.
 
 ### Using Port Forwarding

--- a/mysqloperator/controller/innodbcluster/cluster_api.py
+++ b/mysqloperator/controller/innodbcluster/cluster_api.py
@@ -1662,7 +1662,7 @@ class MySQLPod(K8sInterfaceObject):
 
     @property
     def address_fqdn(self) -> str:
-        return self.name+"."+cast(str, self.spec.subdomain)+"."+self.namespace+".svc.cluster.local"
+        return self.name+"."+cast(str, self.spec.subdomain)+"."+self.namespace+".svc"
 
     @property
     def pod_ip_address(self) -> str:

--- a/mysqloperator/controller/innodbcluster/router_objects.py
+++ b/mysqloperator/controller/innodbcluster/router_objects.py
@@ -201,7 +201,7 @@ spec:
         imagePullPolicy: {spec.router_image_pull_policy}
         env:
         - name: MYSQL_HOST
-          value: {spec.name}-instances.{spec.namespace}.svc.cluster.local
+          value: {spec.name}-instances.{spec.namespace}.svc
         - name: MYSQL_PORT
           value: "3306"
         - name: MYSQL_USER

--- a/mysqloperator/init_main.py
+++ b/mysqloperator/init_main.py
@@ -31,7 +31,7 @@ def init_conf(datadir, pod, cluster, logger):
     initializing for the 1st time.
     """
     server_id = pod.index + cluster.parsed_spec.baseServerId
-    report_host = f"{pod.name}.{cluster.name}-instances.{cluster.namespace}.svc.cluster.local"
+    report_host = f"{pod.name}.{cluster.name}-instances.{cluster.namespace}.svc"
     logger.info(
         f"Setting up configurations for {pod.name}  server_id={server_id}  report_host={report_host}")
 

--- a/tests/data/ssl/router-req.conf
+++ b/tests/data/ssl/router-req.conf
@@ -11,4 +11,4 @@ subjectAltName = @alt_names
 [alt_names]
 DNS.1 = mycluster
 DNS.2 = mycluster.cluster-ssl.svc
-DNS.3 = mycluster.cluster-ssl.svc.cluster.local
+DNS.3 = mycluster.cluster-ssl.svc

--- a/tests/data/ssl/server-req.conf
+++ b/tests/data/ssl/server-req.conf
@@ -10,5 +10,5 @@ keyUsage = keyEncipherment, digitalSignature
 extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 [alt_names]
-DNS.1 = *.mycluster-instances.cluster-ssl.svc.cluster.local
+DNS.1 = *.mycluster-instances.cluster-ssl.svc
 DNS.2 = *.mycluster-instances

--- a/tests/e2e/clone.yaml
+++ b/tests/e2e/clone.yaml
@@ -9,7 +9,7 @@ spec:
   image: mysql/mysql-server:8.0.25
   initDB:
     clone:
-      donorUrl: root@mycluster-0.mycluster-instances.testns.svc.cluster.local:3306
+      donorUrl: root@mycluster-0.mycluster-instances.testns.svc:3306
       secretKeyRef:
         name: mypwds
         rootPasswordKey: rootPassword

--- a/tests/e2e/mysqloperator/cluster/check_group.py
+++ b/tests/e2e/mysqloperator/cluster/check_group.py
@@ -44,7 +44,7 @@ def check_instance(test, icobj, all_pods, pod, is_primary, num_sessions=None, ve
     for p in all_pods:
         if p != pod:
             group_seeds.add(p["metadata"]["name"]+"."+icobj["metadata"]["name"] +
-                            "-instances."+icobj["metadata"]["namespace"]+".svc.cluster.local:3306")
+                            "-instances."+icobj["metadata"]["namespace"]+".svc:3306")
 
     name = pod["metadata"]["name"]
     base_id = icobj["spec"].get("baseServerId", 1000)

--- a/tests/e2e/mysqloperator/cluster/cluster_ssl_t.py
+++ b/tests/e2e/mysqloperator/cluster/cluster_ssl_t.py
@@ -104,10 +104,10 @@ def check_ssl(self, ns, pod, ca=None, crl=None, ssl_cert_days=None):
         check_verify_ca(self, ns, pod, 3306, capath, expected_host=pod)
 
         # check connecting to server with VERIFY_IDENTITY and CA directly from operator pod
-        check_connect_via_operator_pod(self, f"{pod}.mycluster-instances.{ns}.svc.cluster.local:3306", capath, ssl_mode="VERIFY_CA")
-        check_connect_via_operator_pod(self, f"{pod}.mycluster-instances.{ns}.svc.cluster.local:3306", capath, ssl_mode="VERIFY_IDENTITY")
+        check_connect_via_operator_pod(self, f"{pod}.mycluster-instances.{ns}.svc:3306", capath, ssl_mode="VERIFY_CA")
+        check_connect_via_operator_pod(self, f"{pod}.mycluster-instances.{ns}.svc:3306", capath, ssl_mode="VERIFY_IDENTITY")
     else:
-        check_connect_via_operator_pod(self, f"{pod}.mycluster-instances.{ns}.svc.cluster.local:3306", None, ssl_mode="REQUIRED")
+        check_connect_via_operator_pod(self, f"{pod}.mycluster-instances.{ns}.svc:3306", None, ssl_mode="REQUIRED")
 
 
 def check_router_ssl(self, ns, pod, ca=None, has_cert=False, crl=None):
@@ -142,9 +142,9 @@ def check_router_ssl(self, ns, pod, ca=None, has_cert=False, crl=None):
         check_verify_ca(self, ns, pod, 6446, capath, expected_host="mycluster-0")
 
         # check connecting to router with VERIFY_CA directly from operator pod to the service
-        check_connect_via_operator_pod(self, f"mycluster.{ns}.svc.cluster.local:6446", capath, ssl_mode="VERIFY_CA")
+        check_connect_via_operator_pod(self, f"mycluster.{ns}.svc:6446", capath, ssl_mode="VERIFY_CA")
         # VERIFY_IDENTITY doesn't work because we're connecting to the service
-        #check_connect_via_operator_pod(self, f"mycluster.{ns}.svc.cluster.local:6446", capath, ssl_mode="VERIFY_IDENTITY")
+        #check_connect_via_operator_pod(self, f"mycluster.{ns}.svc:6446", capath, ssl_mode="VERIFY_IDENTITY")
 
 class ClusterSSL(tutil.OperatorTest):
     default_allowed_op_errors = COMMON_OPERATOR_ERRORS

--- a/tests/e2e/mysqloperator/cluster/cluster_t.py
+++ b/tests/e2e/mysqloperator/cluster/cluster_t.py
@@ -702,35 +702,35 @@ spec:
 
         # check classic session to R/W port
         self.verify_routing(
-            f"mycluster.{self.ns}.svc.cluster.local:3306",
-            f"mycluster-0.mycluster-instances.{self.ns}.svc.cluster.local:3306")
+            f"mycluster.{self.ns}.svc:3306",
+            f"mycluster-0.mycluster-instances.{self.ns}.svc:3306")
 
         # check classic session to alternate R/W port
         self.verify_routing(
-            f"mycluster.{self.ns}.svc.cluster.local:6446",
-            f"mycluster-0.mycluster-instances.{self.ns}.svc.cluster.local:3306")
+            f"mycluster.{self.ns}.svc:6446",
+            f"mycluster-0.mycluster-instances.{self.ns}.svc:3306")
 
         # check classic session to R/O port
         self.verify_routing(
-            f"mycluster.{self.ns}.svc.cluster.local:6447",
-            [f"mycluster-1.mycluster-instances.{self.ns}.svc.cluster.local:3306",
-                f"mycluster-2.mycluster-instances.{self.ns}.svc.cluster.local:3306"])
+            f"mycluster.{self.ns}.svc:6447",
+            [f"mycluster-1.mycluster-instances.{self.ns}.svc:3306",
+                f"mycluster-2.mycluster-instances.{self.ns}.svc:3306"])
 
         # check X session to R/W port
         self.verify_routing(
-            f"mycluster.{self.ns}.svc.cluster.local:33060",
-            f"mycluster-0.mycluster-instances.{self.ns}.svc.cluster.local:3306")
+            f"mycluster.{self.ns}.svc:33060",
+            f"mycluster-0.mycluster-instances.{self.ns}.svc:3306")
 
         # check X session to alternate R/W port
         self.verify_routing(
-            f"mycluster.{self.ns}.svc.cluster.local:6448",
-            f"mycluster-0.mycluster-instances.{self.ns}.svc.cluster.local:3306")
+            f"mycluster.{self.ns}.svc:6448",
+            f"mycluster-0.mycluster-instances.{self.ns}.svc:3306")
 
         # check X session to R/O port
         self.verify_routing(
-            f"mycluster.{self.ns}.svc.cluster.local:6449",
-            [f"mycluster-1.mycluster-instances.{self.ns}.svc.cluster.local:3306",
-                f"mycluster-2.mycluster-instances.{self.ns}.svc.cluster.local:3306"])
+            f"mycluster.{self.ns}.svc:6449",
+            [f"mycluster-1.mycluster-instances.{self.ns}.svc:3306",
+                f"mycluster-2.mycluster-instances.{self.ns}.svc:3306"])
 
         kutil.delete_po("appns", "testpod")
         kutil.delete_ns("appns")
@@ -891,7 +891,7 @@ spec:
         kutil.exec(self.ns, ("mycluster-0", "sidecar"),
                    ["mysqlsh", "root:sakila@localhost", "--",
                     "cluster", "set-primary-instance",
-                    f"mycluster-0.mycluster-instances.{self.ns}.svc.cluster.local:3306"])
+                    f"mycluster-0.mycluster-instances.{self.ns}.svc:3306"])
 
         cross_sync_gtids(
             self.ns, ["mycluster-0", "mycluster-1", "mycluster-2"],
@@ -966,7 +966,7 @@ spec:
         check_group.check_data(self, all_pods)
 
         kutil.exec(self.ns, ("mycluster-0", "sidecar"), ["mysqlsh", "root:sakila@localhost", "--", "cluster",
-                                                         "set-primary-instance", f"mycluster-0.mycluster-instances.{self.ns}.svc.cluster.local:3306"])
+                                                         "set-primary-instance", f"mycluster-0.mycluster-instances.{self.ns}.svc:3306"])
 
     def test_4_recover_delete_and_wipe_1_of_3(self):
         # delete the pv and pvc first, which will block because until the pod

--- a/tests/e2e/mysqloperator/cluster/initdb_t.py
+++ b/tests/e2e/mysqloperator/cluster/initdb_t.py
@@ -98,7 +98,7 @@ spec:
   baseServerId: 2000
   initDB:
     clone:
-      donorUrl: root@mycluster-0.mycluster-instances.{self.ns}.svc.cluster.local:3306
+      donorUrl: root@mycluster-0.mycluster-instances.{self.ns}.svc:3306
       secretKeyRef:
         name: donorpwds
 """

--- a/tests/e2e/mysqloperator/cluster/router_t.py
+++ b/tests/e2e/mysqloperator/cluster/router_t.py
@@ -76,7 +76,7 @@ spec:
     def test_1_load_distribution(self):
         def check(port, hosts_expected):
             # checks that we connect to both secondaries at least once
-            h = tutil.run_from_operator_pod(f"mysql://root:sakila@mycluster.{self.ns}.svc.cluster.local:{port}",
+            h = tutil.run_from_operator_pod(f"mysql://root:sakila@mycluster.{self.ns}.svc:{port}",
                 "print(session.run_sql('select @@hostname').fetch_one()[0])")
             self.logger.debug(h)
             hosts_expected.remove(h)
@@ -98,7 +98,7 @@ spec:
 
         def check(secondaries_seen):
             # checks that we connect to both secondaries at least once
-            h = tutil.run_from_operator_pod(f"mysql://root:sakila@mycluster.{self.ns}.svc.cluster.local:6447",
+            h = tutil.run_from_operator_pod(f"mysql://root:sakila@mycluster.{self.ns}.svc:6447",
                 "print(session.run_sql('select @@hostname').fetch_one()[0])")
             secondaries_seen.add(h)
             return len(secondaries_seen) == 2
@@ -108,12 +108,12 @@ spec:
             s.exec_sql("stop group_replication")
 
         # connect through the router
-        h = tutil.run_from_operator_pod(f"root:sakila@mycluster.{self.ns}.svc.cluster.local:6446",
+        h = tutil.run_from_operator_pod(f"root:sakila@mycluster.{self.ns}.svc:6446",
                 "print(session.run_sql('select @@hostname').fetch_one()[0])")
         self.assertEqual("mycluster-0", h)
 
         for _ in range(5):
-            h = tutil.run_from_operator_pod(f"root:sakila@mycluster.{self.ns}.svc.cluster.local:6447",
+            h = tutil.run_from_operator_pod(f"root:sakila@mycluster.{self.ns}.svc:6447",
                 "print(session.run_sql('select @@hostname').fetch_one()[0])")
             self.assertIn(h, ["mycluster-2"])
 


### PR DESCRIPTION
When cluster domain is different from `cluster.local` operator has dns resolution problems
```
Error executing mysqlsh.connect_dba, retrying after 4s: MySQL Error (2005): mysqlsh.connect_dba: Unknown MySQL server host 'mycluster-0.mycluster-instances.default.svc.cluster.local' (-2)
```
Using dns name like `svc-name.namespace.svc` should  be enough in all cases.