### PR TITLE
Add missing "dumpOptions" in a helm template file named deployment_cluster.yaml

### DIFF
--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -272,7 +272,7 @@ spec:
         {{- if $isDumpInstance }}
     dumpInstance:
           {{- if hasKey $backupProfile "dumpOptions" }}
-      dumpOptions: {{ toYaml $backupProfile.dumpOptions | nindent 10 }}
+      dumpOptions: {{ toYaml $backupProfile.dumpOptions | nindent 8 }}
           {{- end }}
         {{- else if $isSnapshot }}
     snapshot:

--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -271,6 +271,9 @@ spec:
         {{- $backupProfile := ternary $profile.dumpInstance $profile.snapshot $isDumpInstance }}
         {{- if $isDumpInstance }}
     dumpInstance:
+          {{- if hasKey $backupProfile "dumpOptions" }}
+      dumpOptions: {{ toYaml $backupProfile.dumpOptions | nindent 10 }}
+          {{- end }}
         {{- else if $isSnapshot }}
     snapshot:
         {{- else }}
@@ -338,6 +341,9 @@ spec:
         {{- end }}
         {{- if $isDumpInstance }}
       dumpInstance:
+          {{- if hasKey $backupProfile "dumpOptions" }}
+        dumpOptions: {{ toYaml $backupProfile.dumpOptions | nindent 10 }}
+          {{- end }}
         {{- else if $isSnapshot }}
       snapshot:
         {{- end }}


### PR DESCRIPTION
Add logic to check and parse "dumpOptions" value in the `deployment_cluster.yaml` file.