### PR TITLE
Added "overrideNamespace"

### DIFF
--- a/helm/mysql-innodbcluster/templates/cluster_secret.yaml
+++ b/helm/mysql-innodbcluster/templates/cluster_secret.yaml
@@ -1,7 +1,7 @@
 {{- $cluster_name :=  default "mycluster" .Release.Name }}
 
 {{- $rand_password := randAscii 21 }}
-{{- $root_password := .Values.credentials.root.password | default $rand_password }}
+{{- $root_password := .Values.credentials.root.password | default ($rand_password | nospace) }}
 
 apiVersion: v1
 kind: Secret
@@ -11,4 +11,4 @@ metadata:
 stringData:
   rootUser: {{ .Values.credentials.root.user | default "root" | quote }}
   rootHost: {{ .Values.credentials.root.host | default "%%" | quote }}
-  rootPassword: {{ $root_password | nospace | b64enc | quote }}
+  rootPassword: {{ $root_password | b64enc | quote }}

--- a/helm/mysql-innodbcluster/templates/cluster_secret.yaml
+++ b/helm/mysql-innodbcluster/templates/cluster_secret.yaml
@@ -1,4 +1,8 @@
 {{- $cluster_name :=  default "mycluster" .Release.Name }}
+
+{{- $rand_password := randAscii 21 }}
+{{- $root_password := .Values.credentials.root.password | default $rand_password }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,4 +11,4 @@ metadata:
 stringData:
   rootUser: {{ .Values.credentials.root.user | default "root" | quote }}
   rootHost: {{ .Values.credentials.root.host | default "%%" | quote }}
-  rootPassword: {{ required "credentials.root.password is required" .Values.credentials.root.password | quote }}
+  rootPassword: {{ $root_password | nospace | b64enc | quote }}

--- a/helm/mysql-innodbcluster/templates/cluster_secret.yaml
+++ b/helm/mysql-innodbcluster/templates/cluster_secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $cluster_name }}-cluster-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.overrideNamespace .Release.Namespace }}
 stringData:
   rootUser: {{ .Values.credentials.root.user | default "root" | quote }}
   rootHost: {{ .Values.credentials.root.host | default "%%" | quote }}

--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -32,7 +32,7 @@ apiVersion: mysql.oracle.com/v2
 kind: InnoDBCluster
 metadata:
   name: {{ $cluster_name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ coalesce .Values.overrideNamespace .Release.Namespace }}
 spec:
   instances: {{ required "serverInstances is required" .Values.serverInstances }}
   tlsUseSelfSigned: {{ $use_self_signed }}

--- a/helm/mysql-innodbcluster/templates/service_account_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/service_account_cluster.yaml
@@ -1,6 +1,6 @@
 {{- $disable_lookups:= .Values.disableLookups }}
 {{- $cluster_name :=  default "mycluster" .Release.Name }}
-{{- $install_namespace := .Release.Namespace }}
+{{- $install_namespace := coalesce .Values.overrideNamespace .Release.Namespace }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/mysql-innodbcluster/values.yaml
+++ b/helm/mysql-innodbcluster/values.yaml
@@ -1,3 +1,5 @@
+overrideNamespace: null
+
 image:
   pullPolicy: IfNotPresent
   pullSecrets:


### PR DESCRIPTION
I added the possibility to define a different namespace through the "overrideNamespace" directive; this allows for a better ability to use the innodb chart as a dependency in application charts.