### PR TITLE
Allow setting spec.router.instances to zero

### DIFF
--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -5,13 +5,12 @@
 {{- $forbiddenVersions := list "8.0.29" }}
 {{- $imagePullPolicies := list "ifnotpresent" "always" "never" }}
 {{- $serverVersion := .Values.serverVersion | default .Chart.AppVersion }}
-{{- if and ((.Values).routerInstances) (((.Values).router).instances) }}
+{{- if and (hasKey (.Values) "routerInstances") (hasKey ((.Values).router) "instances") }}
   {{- if ne (toString ((.Values).routerInstances)) (toString (((.Values).router).instances)) }}
     {{- $err := printf "routerInstances and router.instances both are specified and have different values %s and %s. Use only one" (toString ((.Values).routerInstances)) (toString (((.Values).router).instances)) }}
     {{- fail $err }}
   {{- end }}
 {{- end }}
-{{- $routerInstances := coalesce ((.Values).routerInstances) (((.Values).router).instances) }}
 {{- if lt $serverVersion $minimalVersion }}
   {{- $err := printf "It is not possible to use MySQL version %s . Please, use %s or above" $serverVersion $minimalVersion }}
   {{- fail $err }}
@@ -37,7 +36,13 @@ spec:
   instances: {{ required "serverInstances is required" .Values.serverInstances }}
   tlsUseSelfSigned: {{ $use_self_signed }}
   router:
-    instances: {{ required "router.instances is required" $routerInstances }}
+{{- if hasKey (.Values) "routerInstances" }}
+    instances: {{ .Values.routerInstances }}
+{{- else if hasKey ((.Values).router) "instances" }}
+    instances: {{ .Values.router.instances }}
+{{- else }}
+  {{- fail "router.instances is required" }}
+{{- end }}
 {{- if (((.Values).router).podSpec) }}
     podSpec:  {{ toYaml (((.Values).router).podSpec) | nindent 6 }}
 {{- end }}

--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -6,8 +6,8 @@
 {{- $imagePullPolicies := list "ifnotpresent" "always" "never" }}
 {{- $serverVersion := .Values.serverVersion | default .Chart.AppVersion }}
 {{- if and ((.Values).routerInstances) (((.Values).router).instances) }}
-  {{- if ne ((.Values).routerInstances) (((.Values).router).instances) }}
-    {{- $err := printf "routerInstances and router.instances both are specified and have different values %d and %d. Use only one" ((.Values).routerInstances) (((.Values).router).instances) }}
+  {{- if ne (toString ((.Values).routerInstances)) (toString (((.Values).router).instances)) }}
+    {{- $err := printf "routerInstances and router.instances both are specified and have different values %s and %s. Use only one" (toString ((.Values).routerInstances)) (toString (((.Values).router).instances)) }}
     {{- fail $err }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
`InnoDBCluster` resource can have zero router instances. However, Helm
considers zero to be an empty value (see [`default` function](https://helm.sh/docs/chart_template_guide/function_list/#default)), so we
cannot rely on `coalesce` Helm function to source `spec.router.instances`
from one of the following values:

1. `routerInstances`
2. `router.instances`

We change implementation which relies on Helm functions which use
“emptiness” to the implementation which checks if a value is defined in
parent dict. We do not introduce any additional validation like checking
if the value is an integer zero or any other value or type. This has
been validated by Kubernetes using CRD so far, Helm properly reports
this back, and we do not change this.

We also fix validation of source for `spec.router.instances` which can be of different types by converting them to strings.