### PR TITLE
fix clone from an instance, ref to wrong field

### DIFF
--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -207,7 +207,7 @@ spec:
       donorUrl: {{ required "initDB.clone.donorUrl is required" .donorUrl }}
       rootUser: {{ .rootUser | default "root" }}
       secretKeyRef:
-        name: {{ required "initDB.clone.credentials is required" .credentials }}
+        name: {{ required "initDB.clone.secretKeyRef.name is required" .secretKeyRef.name }}
     {{- end }}
   {{- end }}
 


### PR DESCRIPTION
pointed to the wrong fields, should be .secretKeyRef.name