### PR TITLE
Add Timezone Support To Backup Schedule

### DIFF
--- a/deploy/deploy-crds.yaml
+++ b/deploy/deploy-crds.yaml
@@ -626,6 +626,9 @@ spec:
                         type: boolean
                         default: true
                         description: "Whether the schedule is enabled or not"
+                      timeZone:
+                        type: string
+                        description: "Enable timezone to the backup schedule, example: 'America/New_York'"
                 logs:
                   type: object
                   properties:

--- a/mysqloperator/controller/backup/backup_api.py
+++ b/mysqloperator/controller/backup/backup_api.py
@@ -117,6 +117,7 @@ class BackupSchedule:
         self.backupProfile: Optional[BackupProfile] = None
         self.schedule: str = ""
         self.enabled: bool = False
+        self.timeZone: str = ""
         self.deleteBackupData: bool = False # unused
 
     def add_to_pod_spec(self, pod_spec: dict, container_name: str) -> None:
@@ -132,6 +133,8 @@ class BackupSchedule:
         self.enabled = dget_bool(spec, "enabled", prefix, default_value=False)
 
         self.backupProfileName = dget_str(spec, "backupProfileName", prefix, default_value= "")
+
+        self.timeZone = dget_str(spec, "timeZone", prefix, default_value= "")
 
         self.schedule = dget_str(spec, "schedule", prefix)
         if not self.schedule:
@@ -158,7 +161,7 @@ class BackupSchedule:
                 raise ApiSpecError(f"Invalid backupProfileName '{self.backupProfileName}' in cluster {self.cluster_spec.namespace}/{self.cluster_spec.name}")
 
     def __str__(self) -> str:
-        return f"Object BackupSchedule scheduleName={self.name} deleteBackupData={self.deleteBackupData} enabled={self.enabled} backupProfileName={self.backupProfileName} schedule={self.schedule} profile={self.backupProfile}"
+        return f"Object BackupSchedule scheduleName={self.name} deleteBackupData={self.deleteBackupData} enabled={self.enabled} backupProfileName={self.backupProfileName} schedule={self.schedule} profile={self.backupProfile} timeZone={self.timeZone}"
 
     def __eq__(self, other : 'BackupSchedule') -> bool:
         assert isinstance(other, BackupSchedule)
@@ -169,6 +172,7 @@ class BackupSchedule:
                 self.backupProfile == other.backupProfile and \
                 self.schedule == other.schedule and \
                 self.deleteBackupData == other.deleteBackupData and \
+                self.timeZone == other.timeZone and \
                 self.enabled == other.enabled)
         return eq
 
@@ -182,6 +186,7 @@ class MySQLBackupSpec:
         self.backupProfileName: str = ""
         self.backupProfile: BackupProfile = None
         self.deleteBackupData: bool = False # unused
+        self.timeZone: str = ""
         self.addTimestampToBackupDirectory: bool = True
         self.operator_image: str = ""
         self.operator_image_pull_policy: str = ""
@@ -198,6 +203,7 @@ class MySQLBackupSpec:
         self.backupProfileName = dget_str(spec, "backupProfileName", "spec", default_value="")
         self.backupProfile = self.parse_backup_profile(dget_dict(spec, "backupProfile", "spec", {}), "spec.backupProfile")
         self.deleteBackupData = dget_bool(spec, "deleteBackupData", "spec", default_value=False)
+        self.timeZone = dget_str(spec, "timeZone", "spec", default_value="")
         self.addTimestampToBackupDirectory = dget_bool(spec, "addTimestampToBackupDirectory", "spec", default_value=True)
 
         if self.backupProfileName and self.backupProfile:

--- a/mysqloperator/controller/backup/backup_objects.py
+++ b/mysqloperator/controller/backup/backup_objects.py
@@ -208,6 +208,9 @@ def patch_cron_template_for_backup_schedule(base: dict, cluster_name: str, sched
     new_object["spec"]["schedule"] = schedule_profile.schedule
     new_object["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"][0]["command"].extend(["--schedule-name", schedule_profile.name])
 
+    if schedule_profile.timeZone:
+        new_object["spec"]["timeZone"] = schedule_profile.timeZone
+
     metadata = {}
     if schedule_profile.backupProfile.podAnnotations:
         metadata['annotations'] = schedule_profile.backupProfile.podAnnotations


### PR DESCRIPTION
Add specific timezone support to backup schedules.

Kubernetes supports the timezone field in CronJob [resources](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones) from version v1.25 onwards.