### PR TITLE
To add the support for declaring additional init containers.

### DIFF
--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -34,6 +34,10 @@ metadata:
   name: {{ $cluster_name }}
   namespace: {{ .Release.Namespace }}
 spec:
+  initContainers:
+    { { - if .Values.initContainers } }
+      { { - include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 } }
+      { { - end } }
   instances: {{ required "serverInstances is required" .Values.serverInstances }}
   tlsUseSelfSigned: {{ $use_self_signed }}
   router:

--- a/helm/mysql-innodbcluster/values.yaml
+++ b/helm/mysql-innodbcluster/values.yaml
@@ -4,6 +4,17 @@ image:
     enabled: false
     secretName:
 
+## @param initContainers Add additional init containers.
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: []
 
 credentials:
   root:


### PR DESCRIPTION
In my production-grade application where I am deploying my cloud native tool end to end via a single master helm chart. Where I want my MySQL deployed via helm chart, to wait for my storage pods to come up and to be in a healthy state, this flow can be implemented and managed easily with the support of init container.

Further reason for this change request, as follows:

1. Operational Flexibility:

    The inclusion of support for declaring additional init containers provides operators with enhanced operational flexibility.
    Allows customization of the initialization process to accommodate diverse deployment scenarios and unique requirements.

2. Advanced Configuration:

    Certain deployments may necessitate specific pre-initialization steps or dependencies, which can be seamlessly integrated using custom init containers.
    Empower users to define complex initialization workflows tailored to their infrastructure and operational needs.
