### PR TITLE
Add priority class to the innodb cluster

### DIFF
--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -444,6 +444,9 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
+    {{- if .Values.priorityClassName }}
+    priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
     {{- if hasKey $replica "mycnf" }}
     mycnf: | {{- if not (hasPrefix "[mysqld]" (($replica).mycnf) ) }}{{- "[mysqld]" | nindent 6 }}{{- end }}{{ (($replica).mycnf) | nindent 6 }}{{- end }}
     {{- if hasKey $replica "instances" }}

--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -444,8 +444,8 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
-    {{- if .Values.priorityClassName }}
-    priorityClassName: {{ .Values.priorityClassName }}
+    {{- if .Values.podPriorityClassName }}
+    priorityClassName: {{ .Values.podPriorityClassName }}
     {{- end }}
     {{- if hasKey $replica "mycnf" }}
     mycnf: | {{- if not (hasPrefix "[mysqld]" (($replica).mycnf) ) }}{{- "[mysqld]" | nindent 6 }}{{- end }}{{ (($replica).mycnf) | nindent 6 }}{{- end }}

--- a/helm/mysql-innodbcluster/templates/priority_class.yaml
+++ b/helm/mysql-innodbcluster/templates/priority_class.yaml
@@ -1,0 +1,11 @@
+{{- $cluster_name :=  default "mycluster" .Release.Name }}
+{{- if .Values.podPriorityClassName.create }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ $cluster_name }}
+  namespace: {{ .Release.Namespace }}
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+value: {{ .Values.podPriorityClassName.priority }}
+{{- end }}

--- a/helm/mysql-innodbcluster/values.yaml
+++ b/helm/mysql-innodbcluster/values.yaml
@@ -29,6 +29,13 @@ baseServerId: 1000
 #  podAnnotations:
 #  podLabels:
 
+podPriorityClassName:
+  # If create is false with no name set, no podPriorityClassName is specified.
+  create: true
+  # If not set a name is generated using the fullname template 
+  name: ""
+  priority: 1000000
+
 #logs:
 #  error:
 #    enabled: true


### PR DESCRIPTION
Because of the eviction policy from k8s, lower priority pods are getting evicted and in our case, the innodb cluster pods got evicted and finalizer prevented it from completing graceful shutdown and it hangs.
So added priority class on helm for the innodb cluster pod to ensure they have a higher priority compared to other pods in the cluster. 