### PR TITLE
Fix bug#114311 - on_startup process fails

### DIFF
--- a/mysqloperator/controller/innodbcluster/operator_cluster.py
+++ b/mysqloperator/controller/innodbcluster/operator_cluster.py
@@ -43,8 +43,11 @@ def on_group_view_change(cluster: InnoDBCluster, members: list[tuple], view_id_c
 def monitor_existing_clusters(clusters: List[InnoDBCluster], logger: Logger) -> None:
     for cluster in clusters:
         if cluster.get_create_time():
-            g_group_monitor.monitor_cluster(
-                cluster, on_group_view_change, logger)
+            try:
+                g_group_monitor.monitor_cluster(
+                    cluster, on_group_view_change, logger)
+            except Exception as exc:
+                logger.warn(f"Error while monitoring {cluster.namespace}/{cluster.name}: {exc}")
 
 
 def ensure_backup_schedules_use_current_image(clusters: List[InnoDBCluster], logger: Logger) -> None:
@@ -58,9 +61,12 @@ def ensure_backup_schedules_use_current_image(clusters: List[InnoDBCluster], log
 
 def ensure_router_accounts_are_uptodate(clusters: List[InnoDBCluster], logger: Logger) -> None:
     for cluster in clusters:
-        router_objects.update_router_account(cluster,
-                                             lambda: logger.warning(f"Cluster {cluster.namespace}/{cluster.name} unreachable"),
-                                             logger)
+        try:
+            router_objects.update_router_account(cluster,
+                                                lambda: logger.warning(f"Cluster {cluster.namespace}/{cluster.name} unreachable"),
+                                                logger)
+        except Exception as exc:
+            logger.warn(f"Error while ensuring router accounts are up-to-date for {cluster.namespace}/{cluster.name}: {exc}")
 
 
 def ignore_404(f) -> Any:


### PR DESCRIPTION
### Description
When incomplete InnoDBCluster exsits, the on_startup process of mysql-operator fails, and mysql-operator pod can't reach the Ready state 1/1. 
Examples of an incomplete it include missing secret resources related to  InnoDBCluster. 
The existence of an incomplete it hinders the startup of mysq-operator and affects the normal operation of other it.

### Suggested fix
Appropriately handle exceptions in the section checking InnoDBClusters during on_startup, ensuring that on_startup doesn't fail if one check fails.

https://bugs.mysql.com/bug.php?id=114311