### PR TITLE
Added bootstrapOptions for router

### DIFF
--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -38,6 +38,9 @@ spec:
   tlsUseSelfSigned: {{ $use_self_signed }}
   router:
     instances: {{ required "router.instances is required" $routerInstances }}
+{{- if (((.Values).router).bootstrapOptions) }}
+    bootstrapOptions:  {{ toYaml (((.Values).router).bootstrapOptions) | nindent 4 }}
+{{- end }}
 {{- if (((.Values).router).podSpec) }}
     podSpec:  {{ toYaml (((.Values).router).podSpec) | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
bootstrapOptions for router

in order to use such values in helm chart mysql-innodbcluster

```
router:
  bootstrapOptions:
  - --conf-set-option=DEFAULT.max_total_connections=4096
```