### PR TITLE
Fix mysqld socket path in generated options file 

### DIFF
--- a/mysqloperator/controller/innodbcluster/cluster_api.py
+++ b/mysqloperator/controller/innodbcluster/cluster_api.py
@@ -225,7 +225,7 @@ class MetriscSpec:
 
             config = f"""[client]
 user={self.dbuser_name}
-socket=unix:///var/run/mysqld/mysql.sock
+socket=/var/run/mysqld/mysql.sock
 """
 
             return [


### PR DESCRIPTION
The MySQL docks don't include `unix://` in socket paths. Including this breaks `mysqld_monitor` as the mysql driver tries to use `unix:///var/run/mysqld/mysqld.socket` as the full path which doesn't work. 

See https://dev.mysql.com/doc/refman/8.4/en/option-files.html for an example. 