### PR TITLE
fix(rbac): allow mysql-sidecar to watch namespaces and CRDs across namespaces

### DIFF
--- a/deploy/deploy-operator.yaml
+++ b/deploy/deploy-operator.yaml
@@ -99,6 +99,12 @@ rules:
   - apiGroups: ["mysql.oracle.com"]
     resources: ["mysqlbackups/status"]
     verbs: ["get", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [list, watch]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: [list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/mysql-operator/templates/cluster_role_sidecar.yaml
+++ b/helm/mysql-operator/templates/cluster_role_sidecar.yaml
@@ -38,6 +38,12 @@ rules:
   - apiGroups: ["mysql.oracle.com"]
     resources: ["mysqlbackups/status"]
     verbs: ["get", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [list, watch]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: [list, watch]
 ---
 # Role for the switchover CronJob
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR fixes an issue where the **MySQL Operator sidecar pod** fails when an `InnoDBCluster` is deployed in a different namespace than the operator itself. Specifically, when the operator is installed (e.g. in `mysql-operator` namespace) and a cluster is created in another namespace (e.g. `default`), the sidecar service account throws errors due to insufficient permissions for watching **namespaces** and **CRDs**.

### Steps to Reproduce

1. Install the operator in its own namespace:

   ```bash
   helm repo add mysql-operator https://mysql.github.io/mysql-operator/
   helm repo update
   helm install mysql-operator mysql-operator/mysql-operator --namespace mysql-operator --create-namespace
   ```

2. Apply an `InnoDBCluster` manifest in a different namespace (e.g. `default`):

   ```yaml
   apiVersion: mysql.oracle.com/v2
   kind: InnoDBCluster
   metadata:
     name: mysql-cluster
   spec:
     instances: 3
     version: "8.0.35"
     secretName: mysql-root-secret
     tlsUseSelfSigned: true
     datadirVolumeClaimTemplate:
       storageClassName: standard
       resources:
         requests:
           storage: "10Gi"
     router:
       instances: 1
   ```

3. Observe the sidecar pod logs – errors appear about missing RBAC permissions for `namespaces` and `customresourcedefinitions`.

### Root Cause

The `mysql-sidecar` `ClusterRole` did not include access to:

* Core `namespaces` resource
* `apiextensions.k8s.io` CRDs

Without these, the sidecar cannot properly watch required resources when clusters are deployed across different namespaces.

### Fix

This PR updates the `ClusterRole` for `mysql-sidecar` to include:

```yaml
- apiGroups: [""]
  resources: ["namespaces"]
  verbs: ["list", "watch"]
- apiGroups: ["apiextensions.k8s.io"]
  resources: ["customresourcedefinitions"]
  verbs: ["list", "watch"]
```

### Testing

* Installed operator in `mysql-operator` namespace.
* Created an `InnoDBCluster` in `default` namespace.
* Verified that the sidecar pod no longer throws RBAC errors.

### Notes

This change is backwards-compatible and does not affect existing clusters running in the same namespace as the operator.
