### PR TITLE
Add support for existing secrets in Helm chart

### DIFF
--- a/helm/mysql-innodbcluster/templates/cluster_secret.yaml
+++ b/helm/mysql-innodbcluster/templates/cluster_secret.yaml
@@ -1,10 +1,13 @@
-{{- $cluster_name :=  default "mycluster" .Release.Name }}
+{{- $cluster_name := default "mycluster" .Release.Name }}
+{{- if not .Values.credentials.root.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $cluster_name }}-cluster-secret
   namespace: {{ .Release.Namespace }}
+type: Opaque
 stringData:
   rootUser: {{ .Values.credentials.root.user | default "root" | quote }}
   rootHost: {{ .Values.credentials.root.host | default "%%" | quote }}
-  rootPassword: {{ required "credentials.root.password is required" .Values.credentials.root.password | quote }}
+  rootPassword: {{ required "credentials.root.password is required when credentials.root.existingSecret is not set" .Values.credentials.root.password | quote }}
+{{- end }}

--- a/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
+++ b/helm/mysql-innodbcluster/templates/deployment_cluster.yaml
@@ -69,7 +69,7 @@ spec:
   {{- end }}
     tlsSecretName: {{ $secret_name }}
 {{- end }}
-  secretName: {{ .Release.Name }}-cluster-secret
+  secretName: {{ .Values.credentials.root.existingSecret | default (printf "%s-cluster-secret" .Release.Name) }}
   imagePullPolicy : {{ .Values.image.pullPolicy }}
   baseServerId: {{ required "baseServerId is required" .Values.baseServerId | toString | atoi }}
   version: {{ .Values.serverVersion | default .Chart.AppVersion }}

--- a/helm/mysql-innodbcluster/values.yaml
+++ b/helm/mysql-innodbcluster/values.yaml
@@ -9,12 +9,34 @@ image:
 
 credentials:
   root:
-    user: root
-#    password: sakila
-    host: "%"
+    # Option 1: Provide credentials directly (chart will create a secret)
+    # Only used when existingSecret is not set
+    #user: root
+    #host: "%%"
+    #password: "test"
+
+    # Option 2: Reference an existing Kubernetes secret (recommended for production/GitOps)
+    # When set, user/host/password above are ignored and the chart will not create a secret.
+    #
+    # The referenced secret must contain these keys:
+    #   - rootUser: MySQL root username (e.g., "root")
+    #   - rootHost: MySQL root host pattern (e.g., "%%")
+    #   - rootPassword: MySQL root password
+    #
+    # Example secret:
+    #   apiVersion: v1
+    #   kind: Secret
+    #   metadata:
+    #     name: mysql-root-credentials
+    #   type: Opaque
+    #   stringData:
+    #     rootUser: root
+    #     rootHost: "%%"
+    #     rootPassword: "my-secure-password"
+    existingSecret: "vault-mysql-credentials"
 
 tls:
-  useSelfSigned: false
+  useSelfSigned: true
 #  caSecretName:
 #  serverCertAndPKsecretName:
 #  routerCertAndPKsecretName: # our use router.certAndPKsecretName

--- a/helm/mysql-innodbcluster/values.yaml
+++ b/helm/mysql-innodbcluster/values.yaml
@@ -11,9 +11,10 @@ credentials:
   root:
     # Option 1: Provide credentials directly (chart will create a secret)
     # Only used when existingSecret is not set
-    #user: root
-    #host: "%%"
-    #password: "test"
+    user: root
+    password: sakila
+    host: "%"
+
 
     # Option 2: Reference an existing Kubernetes secret (recommended for production/GitOps)
     # When set, user/host/password above are ignored and the chart will not create a secret.
@@ -33,10 +34,11 @@ credentials:
     #     rootUser: root
     #     rootHost: "%%"
     #     rootPassword: "my-secure-password"
-    existingSecret: "vault-mysql-credentials"
+
+    # existingSecret: ""
 
 tls:
-  useSelfSigned: true
+  useSelfSigned: false
 #  caSecretName:
 #  serverCertAndPKsecretName:
 #  routerCertAndPKsecretName: # our use router.certAndPKsecretName


### PR DESCRIPTION
## Description

Add support for using an existing Kubernetes secret for MySQL root credentials in the Helm chart, enabling secure GitOps workflows and integration with external secret management systems.

## Contributor Checklist

- [x] OCA signed (https://oca.opensource.oracle.com/)
- [x] Changes limited to Helm chart only
- [x] Backward compatible (existing deployments unaffected)
- [x] Values.yaml includes parameter documentation
- [x] Tested locally with both traditional and existingSecret methods

## Motivation

**Current limitation:**
- Helm chart requires `credentials.root.password` in values.yaml
- Not compatible with modern secret management (Vault, External Secrets, etc.)
- Security risk: credentials in Git repositories

## Changes

1. **templates/cluster_secret.yaml**: Conditional secret creation
2. **templates/innodbcluster.yaml**: Reference external secret when provided
3. **values.yaml**: New `credentials.root.existingSecret` parameter

## Testing

Verified with `helm template`:

✅ Traditional method (password in values) works unchanged
✅ With `existingSecret`, chart skips secret creation
✅ InnoDBCluster correctly references external secret
✅ Error message clear when neither password nor existingSecret provided

## Example Usage

**Before (insecure):**
```yaml
credentials:
  root:
    password: "my-password"  # ⚠️ In Git
```

**After (secure):**
```yaml
credentials:
  root:
    existingSecret: mysql-credentials  # ✅ Managed externally
```

## Backward Compatibility

100% backward compatible. Existing deployments continue to work without any changes.