### PR TITLE
Add resources configuration for operator pods

### DIFF
--- a/helm/mysql-operator/templates/deployment.yaml
+++ b/helm/mysql-operator/templates/deployment.yaml
@@ -75,6 +75,9 @@ spec:
               mountPath: /mysqlsh
             - name: tmpdir
               mountPath: /tmp
+          {{- if .Values.resources }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          {{- end }}
           securityContext:
             capabilities:
               drop:

--- a/helm/mysql-operator/values.yaml
+++ b/helm/mysql-operator/values.yaml
@@ -17,6 +17,16 @@ envs:
 
 replicas: 1
 
+## Resource limits and requests for the operator pods
+#resources:
+#  limits:
+#    cpu: 500m
+#    memory: 512Mi
+#  requests:
+#    cpu: 100m
+#    memory: 128Mi
+resources: {}
+
 ## An example of using affinity for scheduling the operator pods
 #affinity:
 #  podAntiAffinity:


### PR DESCRIPTION
This PR adds support for configuring CPU and memory requests/limits for the MySQL Operator deployment pods themselves via Helm values. This enables better integration with clusters that enforce strict resource policies where these values are mandatory.