### PR TITLE
Make operator security contexts configurable and restricted Pod Security compliant

### DIFF
--- a/helm/mysql-operator/templates/deployment.yaml
+++ b/helm/mysql-operator/templates/deployment.yaml
@@ -39,8 +39,10 @@ spec:
       labels:
 {{- include "mysql-operator.deployment.podLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
+{{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.image.pullSecrets.enabled }}
       imagePullSecrets:
       - name: {{ .Values.image.pullSecrets.secretName }}
@@ -120,15 +122,10 @@ spec:
           resources:
 {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            capabilities:
-              drop:
-              - ALL
-            runAsUser: 2
-            allowPrivilegeEscalation: false
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
+{{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: mysqlsh-home
           emptyDir: {}

--- a/helm/mysql-operator/values.yaml
+++ b/helm/mysql-operator/values.yaml
@@ -17,17 +17,20 @@ envs:
 
 replicas: 1
 
-# Pod-level security context
+
+# Pod-level security context for the mysql-operator Pod.
+# Required for Kubernetes restricted Pod Security Standard.
 podSecurityContext:
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
 
-# Container-level security context
+# Container-level security context for the mysql-operator container.
+# Required for Kubernetes restricted Pod Security Standard.
 containerSecurityContext:
   capabilities:
     drop:
-    - ALL
+      - ALL
   runAsUser: 2
   allowPrivilegeEscalation: false
   privileged: false

--- a/helm/mysql-operator/values.yaml
+++ b/helm/mysql-operator/values.yaml
@@ -17,6 +17,25 @@ envs:
 
 replicas: 1
 
+# Pod-level security context
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  runAsUser: 2
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+    
 #deployment:
   #name: mysql-operator
   ## deployment.name is part of the operator's persistent identity.

--- a/helm/mysql-operator/values.yaml
+++ b/helm/mysql-operator/values.yaml
@@ -17,7 +17,6 @@ envs:
 
 replicas: 1
 
-
 # Pod-level security context for the mysql-operator Pod.
 # Required for Kubernetes restricted Pod Security Standard.
 podSecurityContext:


### PR DESCRIPTION
### Summary
This PR makes the MySQL Operator Helm chart compatible with namespaces enforcing the Kubernetes restricted Pod Security Standard.
The operator Deployment previously hardcoded both pod-level and container-level securityContext values, but did not set seccompProfile.type. This causes pod creation to fail in namespaces labeled with:

`pod-security.kubernetes.io/enforce=restricted`

The Kubernetes restricted profile requires workloads to use an allowed seccomp profile such as RuntimeDefault or Localhost, and also requires settings such as non-root execution, disabled privilege escalation, and dropped capabilities. [kubernetes.io]
This change adds configurable Helm values for:

- podSecurityContext
- containerSecurityContext

and sets secure defaults including:

```YAML
seccompProfile:
  type: RuntimeDefaultWeitere Zeilen anzeigen
```

### Problem
When installing the chart into a namespace enforcing the restricted Pod Security Standard, the operator pod is rejected with an error similar to:

```
Error creating: pods "mysql-operator-..." is forbidden:
violates PodSecurity "restricted:latest":
seccompProfile (pod or container "mysql-operator" must setsecurityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

The chart currently hardcodes security contexts in the Deployment template:

```YAML
securityContext:
  runAsNonRoot: true
```

and:

```YAML
securityContext:
  capabilities:
    drop:
      - ALL
  runAsUser: 2
  allowPrivilegeEscalation: false
  privileged: false
  readOnlyRootFilesystem: true
  runAsNonRoot: true
```

However, seccompProfile.type is missing.
Additionally, because these security contexts are not exposed through values.yaml, users cannot fix the issue through Helm values.

### Solution
This PR:

Adds podSecurityContext to values.yaml
Adds containerSecurityContext to values.yaml
Uses these values in the Deployment template
Sets `seccompProfile.type: RuntimeDefault` by default

This keeps the chart secure by default while allowing users to override security context settings through Helm.